### PR TITLE
Added missing include to avoid build falure on g++ 13

### DIFF
--- a/types.hpp
+++ b/types.hpp
@@ -31,6 +31,8 @@
 #ifndef ALIGN3D_TYPES__HPP
 #define ALIGN3D_TYPES__HPP
 
+#include <cstdint>
+
 typedef std::int64_t Int8;    
 typedef std::uint64_t Uint8;
 


### PR DESCRIPTION
Currently `pubchem-align3d` fails building with `g++` >=13 because of a missing `#include`:
```
/build/pubchem_shape/pubchem-align3d/types.hpp:34:14: error: 'int64_t' in namespace 'std' does not name a type
   34 | typedef std::int64_t Int8;
      |              ^~~~~~~
/build/pubchem_shape/pubchem-align3d/types.hpp:35:14: error: 'uint64_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   35 | typedef std::uint64_t Uint8;
      |              ^~~~~~~~

$ $CXX --version
x86_64-conda-linux-gnu-c++ (conda-forge gcc 13.2.0-3) 13.2.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
This small PR fixes the problem.